### PR TITLE
Fix sign up bug

### DIFF
--- a/backend/authz/service/auth_service_test.go
+++ b/backend/authz/service/auth_service_test.go
@@ -8,8 +8,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"testing"
-    "go.mongodb.org/mongo-driver/mongo"
+
 	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func Test_Verify(t *testing.T) {

--- a/backend/authz/storage/storage.go
+++ b/backend/authz/storage/storage.go
@@ -72,7 +72,7 @@ func (s *StorageService) GetUserId(email string) (string, error) {
 	var result types.MongoUserDoc
 	err := coll.FindOne(context.Background(), bson.D{{"user_details.email", email}}).Decode(&result)
 	if err != nil {
-		return "", fmt.Errorf("error finding the user: %v", err)
+		return "", err
 	}
 	fmt.Println(result)
 	return result.UserId, nil

--- a/backend/authz/web/router.go
+++ b/backend/authz/web/router.go
@@ -48,6 +48,23 @@ func requestAccess(c *gin.Context) {
 		})
 		return
 	}
+	granted, err := service.AuthService.RequestAccess(requestAccessReq)
+	if err != nil {
+		c.JSON(404, gin.H{
+			"error": "Bad Request",
+			"msg": err.Error(),
+		})
+		return
+	}
+	if granted {
+		c.JSON(200, gin.H{
+			"access_request": "granted",
+		})
+	} else {
+		c.JSON(200, gin.H{
+			"access_request": "denied",
+		})
+	}
 }
 
 func signup(c *gin.Context) {


### PR DESCRIPTION
There was a bug that prevented signing up. Returning the raw error from storage layer fixes this.

This also adds response codes to request access endpoint

### How to test?
- From the root dir run `docker build -t authz -f docker/authz/Dockerfile backend/authz` to build image
- Run `docker run -it --rm -p 8080:8080 --entrypoint bash authz`
- This should open up a terminal to the docker container
- Add the `conf.yaml` file for the server. Paste the following in terminal
```
mkdir config
cd config
cat > conf.yaml <<EOF
authSecretKey: testkey
llmUsername: llmuser
db:
  host: mymongocluster.r1pcx2q.mongodb.net
  user: sage
  password: oQZxNrwTuKBsmAgu
  database: sage
  appname: users
  users_collection: users
  acls_collection: acls
EOF
```
- Run `cd ../` and `./authz` to start the server
- This should start the server in the docker and expose port on local on 8080
- Run the following curl command:
```bash
curl -X POST \
  -H "Content-Type: application/json" \
  -d '{"email":"newtestemail@mail.com", "password":"testpass"}' \
  localhost:8080/signup
```
- Should be successful